### PR TITLE
feature: Parallel composit

### DIFF
--- a/src/decorator.rs
+++ b/src/decorator.rs
@@ -154,7 +154,7 @@ mod tests {
     fn test_repeat_count() {
         let mut app = App::new();
         app.add_plugins((BehaviorTreePlugin, TesterPlugin));
-        let task = TesterTask::new(0, 1, TaskState::Success);
+        let task = TesterTask::<0>::new(1, TaskState::Success);
         let repeater = ConditionalLoop::new(task, RepeatCount {count: 3});
         let tree = BehaviorTree::new(repeater);
         let _entity = app.world.spawn(tree).id();
@@ -177,7 +177,7 @@ mod tests {
     fn test_invert_result() {
         let mut app = App::new();
         app.add_plugins((BehaviorTreePlugin, TesterPlugin));
-        let task = TesterTask::new(0, 1, TaskState::Success);
+        let task = TesterTask::<0>::new(1, TaskState::Success);
         let inverter = ResultConverter::new(task, |res| !res);
         let tree = BehaviorTree::new(inverter);
         let entity = app.world.spawn(tree).id();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ impl Plugin for BehaviorTreePlugin {
 #[derive(Component)]
 pub struct BehaviorTree {
     root: Arc<dyn Node>,
-    gen: Option<Box<dyn NodeGen>>,
+    runner: Option<NodeRunner>,
     result: Option<NodeResult>,
     world: Arc<Mutex<NullableWorldAccess>>,
 }
@@ -58,15 +58,18 @@ impl BehaviorTree {
     pub fn new(root: Arc<dyn Node>) -> Self {
         Self {
             root,
-            gen: None,
+            runner: None,
             result: None,
             world: Arc::<Mutex::<NullableWorldAccess>>::default(),
         }
     }
+    pub fn result(&self) -> Option<NodeResult> {
+        self.result
+    }
     fn stub(&self) -> Self {
         Self {
             root: Arc::<StubNode>::default(),
-            gen: None,
+            runner: None,
             result: None,
             world: Arc::default(),
         }
@@ -74,8 +77,8 @@ impl BehaviorTree {
 }
 impl Drop for BehaviorTree {
     fn drop(&mut self) {
-        if let Some(gen) = self.gen.as_mut() {
-            gen.abort();
+        if let Some(gen) = self.runner.as_mut() {
+            gen.abort_if_incomplete();
         }
     }
 }
@@ -96,13 +99,28 @@ fn update (
     for (entity, tree, abort) in borrowed_trees.iter_mut() {
         if tree.result.is_some() { continue; }
         let _temporal_world = TemporalWorldSharing::new(tree.world.clone(), world);
-        if tree.gen.is_none() {
-            tree.gen = Some(tree.root.clone().run(tree.world.clone(), *entity));
+
+        match tree.runner.as_mut() {
+            None => {   // Not started yet.
+                if !*abort {
+                    tree.runner = Some(NodeRunner::new(tree.root.clone(), tree.world.clone(), *entity));
+                } else {
+                    tree.result = Some(NodeResult::Aborted);
+                }
+            },
+            Some(runner) => {   // Running.
+                if !*abort {
+                    runner.resume_if_incomplete();
+                } else {
+                    runner.abort_if_incomplete();
+                }
+                tree.result = runner.result();
+            },
         }
-        let Some(gen) = tree.gen.as_mut() else {unreachable!()};
-        if let GeneratorState::Complete(result) = if !*abort {gen.resume()} else {gen.abort()} {
-            tree.result = Some(result);
-            tree.gen = None;
+
+        // Drop used runner.
+        if tree.result.is_some() {
+            tree.runner = None;
         }
     }
 
@@ -143,20 +161,21 @@ pub enum ResumeSignal {
 type Y = ();
 type R = ResumeSignal;
 type C = NodeResult;
+pub type NodeGenState = GeneratorState<Y, C>;
 
 /// Representation of one execution of the node.
 /// In the implementation, it is generator function.
 pub trait NodeGen: Send + Sync {
-    fn resume(&mut self) -> GeneratorState<Y, C>;
-    fn abort(&mut self) -> GeneratorState<Y, C>;
+    fn resume(&mut self) -> NodeGenState;
+    fn abort(&mut self) -> NodeGenState;
 }
 impl<F> NodeGen for Gen<Y, R, F> where
 F: Future<Output = C> + Send + Sync + 'static
 {
-    fn resume(&mut self) -> GeneratorState<Y, C> {
+    fn resume(&mut self) -> NodeGenState {
         Gen::<Y, R, F>::resume_with(self, ResumeSignal::Resume)
     }
-    fn abort(&mut self) -> GeneratorState<Y, C> {
+    fn abort(&mut self) -> NodeGenState {
         Gen::<Y, R, F>::resume_with(self, ResumeSignal::Abort)
     }
 }
@@ -178,11 +197,44 @@ impl Node for StubNode {
 }
 
 
+/// Container for `NodeGen` and its result.
+pub struct NodeRunner {
+    gen: Box<dyn NodeGen>,
+    state: NodeGenState,
+}
+impl NodeRunner {
+    pub fn new(node: Arc<dyn Node>, world: Arc<Mutex<NullableWorldAccess>>, entity: Entity) -> Self {
+        let mut gen = node.run(world, entity);
+        let state = gen.resume();
+        Self { gen, state }
+    }
+    pub fn state(&self) -> &NodeGenState {
+        &self.state
+    }
+    pub fn result(&self) -> Option<NodeResult> {
+        match self.state {
+            NodeGenState::Yielded(()) => None,
+            NodeGenState::Complete(res) => Some(res)
+        }
+    }
+    pub fn resume_if_incomplete(&mut self) {
+        if self.result().is_none() {
+            self.state = self.gen.resume();
+        }
+    }
+    pub fn abort_if_incomplete(&mut self) {
+        if self.result().is_none() {
+            self.state = self.gen.abort();
+        }
+    }
+}
+
+
 async fn complete_or_yield(co: &Co<(), ResumeSignal>, gen: &mut Box<dyn NodeGen>) -> NodeResult {
     let mut state = gen.resume();
     loop {
         match state {
-            GeneratorState::Yielded(yielded_value) => {
+            NodeGenState::Yielded(yielded_value) => {
                 let signal = co.yield_(yielded_value).await;
                 if signal == ResumeSignal::Abort {
                     gen.abort();
@@ -190,7 +242,7 @@ async fn complete_or_yield(co: &Co<(), ResumeSignal>, gen: &mut Box<dyn NodeGen>
                 }
                 state = gen.resume();
             },
-            GeneratorState::Complete(result) => { return result; }
+            NodeGenState::Complete(result) => { return result; }
         }
     }
 }
@@ -219,7 +271,7 @@ mod tests {
             "BehaviorTree should have result that match with the result of the root."
         );
         assert!(
-            tree.gen.is_none(),
+            tree.runner.is_none(),
             "BehaviorTree shold not have generator after the run."
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use self::nullable_access::{NullableWorldAccess, TemporalWorldSharing};
 
 pub mod task;
 pub mod sequential;
+pub mod parallel;
 pub mod decorator;
 
 mod nullable_access;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ mod tests {
     fn test_tree_end_with_result() {
         let mut app = App::new();
         app.add_plugins((BehaviorTreePlugin, TesterPlugin));
-        let task = TesterTask::new(0, 1, TaskState::Success);
+        let task = TesterTask::<0>::new(1, TaskState::Success);
         let tree = BehaviorTree::new(task);
         let entity = app.world.spawn(tree).id();
         app.update();
@@ -228,7 +228,7 @@ mod tests {
     fn test_freeze() {
         let mut app = App::new();
         app.add_plugins((BehaviorTreePlugin, TesterPlugin));
-        let task = TesterTask::new(0, 2, TaskState::Success);
+        let task = TesterTask::<0>::new(2, TaskState::Success);
         let tree = BehaviorTree::new(task);
         let entity = app.world.spawn(tree).id();
         app.update();
@@ -254,7 +254,7 @@ mod tests {
     fn test_abort() {
         let mut app = App::new();
         app.add_plugins((BehaviorTreePlugin, TesterPlugin));
-        let task = TesterTask::new(0, 4, TaskState::Success);
+        let task = TesterTask::<0>::new(4, TaskState::Success);
         let tree = BehaviorTree::new(task);
         let entity = app.world.spawn(tree).id();
         app.update();
@@ -276,7 +276,7 @@ mod tests {
     fn test_drop() {
         let mut app = App::new();
         app.add_plugins((BehaviorTreePlugin, TesterPlugin));
-        let task = TesterTask::new(0, 4, TaskState::Success);
+        let task = TesterTask::<0>::new(4, TaskState::Success);
         let tree = BehaviorTree::new(task);
         let entity = app.world.spawn(tree).id();
         app.update();

--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -1,0 +1,71 @@
+use std::sync::{Arc, Mutex};
+use genawaiter::sync::{Gen, Co};
+
+use bevy::ecs::entity::Entity;
+
+use crate::{Node, NodeResult, NodeRunner, NodeGen, NodeGenState, ResumeSignal, nullable_access::NullableWorldAccess};
+
+pub mod variants;
+
+
+/// Node that runs children in parallel.
+pub struct Parallel {
+    children: Vec<Arc<dyn Node>>,
+    checker: Box<dyn Fn(Vec<&NodeGenState>) -> NodeGenState + 'static + Send + Sync>,
+}
+impl Parallel {
+    pub fn new(
+        children: Vec<Arc<dyn Node>>,
+        checker: impl Fn(Vec<&NodeGenState>) -> NodeGenState + 'static + Send + Sync,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            children,
+            checker: Box::new(checker)
+        })
+    }
+}
+impl Node for Parallel {
+    fn run(self: Arc<Self>, world: Arc<Mutex<NullableWorldAccess>>, entity: Entity) -> Box<dyn NodeGen> {
+        let producer = |co: Co<(), ResumeSignal>| async move {
+            let mut children: Vec<NodeRunner> = self.children.iter().map(|child| {
+                NodeRunner::new(child.clone(), world.clone(), entity)
+            }).collect();
+            let mut node_res: Option<NodeResult> = None;
+            while node_res.is_none() {
+                match (self.checker)(children.iter().map(|runner| runner.state()).collect()) {
+                    NodeGenState::Complete(res) => {
+                        node_res = Some(res);
+                    },
+                    NodeGenState::Yielded(()) => {
+                        let signal = co.yield_(()).await;
+                        match signal {
+                            ResumeSignal::Abort => {
+                                node_res = Some(NodeResult::Aborted);
+                            },
+                            ResumeSignal::Resume => {
+                                for child in children.iter_mut() {
+                                    child.resume_if_incomplete();
+                                }
+                                let debug_print: Vec<String> = children.iter()
+                                .map(|child|
+                                    match child.state() {
+                                        NodeGenState::Yielded(()) => format!("yield"),
+                                        NodeGenState::Complete(res) => format!("{:?}", res),
+                                    }
+                                ).collect();
+                                println!("{:?}", debug_print);
+                            }
+                        }
+                    }
+                }
+            };
+            // abort rest
+            for mut child in children {
+                child.abort_if_incomplete();
+            }
+            node_res.unwrap()
+        };
+        Box::new(Gen::new(producer))
+    }
+}
+

--- a/src/parallel/variants.rs
+++ b/src/parallel/variants.rs
@@ -1,0 +1,245 @@
+use std::sync::{Arc, Mutex};
+use bevy::prelude::*;
+
+use crate::{Node, NodeGen, NodeResult, NodeGenState};
+use crate::nullable_access::NullableWorldAccess;
+use super::Parallel;
+
+
+/// Node that runs children in parallel.
+/// When one of the children completed with Failure,
+///  abort the rest and returns Failure.
+pub struct ParallelAnd {
+    delegate: Arc<Parallel>,
+}
+impl Node for ParallelAnd {
+    fn run(self: Arc<Self>, world: Arc<Mutex<NullableWorldAccess>>, entity: Entity) -> Box<dyn NodeGen> {
+        self.delegate.clone().run(world, entity)
+    }
+}
+impl ParallelAnd {
+    pub fn new(nodes: Vec<Arc<dyn Node>>,) -> Arc<Self> {
+        Arc::new(Self {delegate: Parallel::new(
+            nodes,
+            |states: Vec<&NodeGenState>| {
+                if states.contains(&&NodeGenState::Complete(NodeResult::Failure)) {
+                    NodeGenState::Complete(NodeResult::Failure)
+                } else if states.contains(&&NodeGenState::Yielded(())) {
+                    NodeGenState::Yielded(())
+                } else {
+                    NodeGenState::Complete(NodeResult::Success)
+                }
+            },
+        )})
+    }
+}
+
+/// Node that runs children in parallel.
+/// When one of the children completed with Success,
+///  abort the rest and returns Success.
+pub struct ParallelOr {
+    delegate: Arc<Parallel>,
+}
+impl Node for ParallelOr {
+    fn run(self: Arc<Self>, world: Arc<Mutex<NullableWorldAccess>>, entity: Entity) -> Box<dyn NodeGen> {
+        self.delegate.clone().run(world, entity)
+    }
+}
+impl ParallelOr {
+    pub fn new(nodes: Vec<Arc<dyn Node>>,) -> Arc<Self> {
+        Arc::new(Self {delegate: Parallel::new(
+            nodes,
+            |states: Vec<&NodeGenState>| {
+                if states.contains(&&NodeGenState::Complete(NodeResult::Success)) {
+                    NodeGenState::Complete(NodeResult::Success)
+                } else if states.contains(&&NodeGenState::Yielded(())) {
+                    NodeGenState::Yielded(())
+                } else {
+                    NodeGenState::Complete(NodeResult::Failure)
+                }
+            },
+        )})
+    }
+}
+
+
+/// Node that runs children in parallel.
+/// Complete with Success when all of the children completed.
+pub struct Join {
+    delegate: Arc<Parallel>,
+}
+impl Node for Join {
+    fn run(self: Arc<Self>, world: Arc<Mutex<NullableWorldAccess>>, entity: Entity) -> Box<dyn NodeGen> {
+        self.delegate.clone().run(world, entity)
+    }
+}
+impl Join {
+    pub fn new(nodes: Vec<Arc<dyn Node>>,) -> Arc<Self> {
+        Arc::new(Self {delegate: Parallel::new(
+            nodes,
+            |states: Vec<&NodeGenState>| {
+                if states.contains(&&NodeGenState::Yielded(())) {
+                    NodeGenState::Yielded(())
+                } else {
+                    NodeGenState::Complete(NodeResult::Success)
+                }
+            },
+        )})
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use crate::*;
+    use crate::task::*;
+    use crate::tester_util::{TesterPlugin, TesterTask, TestLog, TestLogEntry};
+    use super::*;
+
+    #[test]
+    fn test_abort() {
+        let mut app = App::new();
+        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        let parallel = Join::new(vec![
+            TesterTask::<0>::new(1, TaskState::Success),
+            TesterTask::<1>::new(2, TaskState::Success),
+            TesterTask::<2>::new(3, TaskState::Failure),
+            TesterTask::<3>::new(4, TaskState::Success),
+        ]);
+        let tree = BehaviorTree::new(parallel);
+        let entity = app.world.spawn(tree).id();
+        app.update();
+        app.update();  // 0, 1, 2, 3
+        app.world.entity_mut(entity).insert(Abort);
+        app.update();  // 1, 2, 3, tree abort
+        app.update();  // nop
+        // Order of the log entries within same frame may change.
+        let expected: HashSet<TestLogEntry> = vec![
+            TestLogEntry {task_id: 0, updated_count: 0, frame: 1},
+            TestLogEntry {task_id: 1, updated_count: 0, frame: 1},
+            TestLogEntry {task_id: 2, updated_count: 0, frame: 1},
+            TestLogEntry {task_id: 3, updated_count: 0, frame: 1},
+            TestLogEntry {task_id: 1, updated_count: 1, frame: 2},
+            TestLogEntry {task_id: 2, updated_count: 1, frame: 2},
+            TestLogEntry {task_id: 3, updated_count: 1, frame: 2},
+        ].into_iter().collect();
+        let found: HashSet<TestLogEntry> = app.world.get_resource::<TestLog>().unwrap().log.clone().into_iter().collect();
+        assert!(
+            found == expected,
+            "Parallel should be able to abort. found: {:?}", found
+        );
+    }
+
+    #[test]
+    fn test_and() {
+        let mut app = App::new();
+        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        let parallel = ParallelAnd::new(vec![
+            TesterTask::<0>::new(1, TaskState::Success),
+            TesterTask::<1>::new(2, TaskState::Success),
+            TesterTask::<2>::new(3, TaskState::Failure),
+            TesterTask::<3>::new(4, TaskState::Success),
+        ]);
+        let tree = BehaviorTree::new(parallel);
+        let _entity = app.world.spawn(tree).id();
+        app.update();
+        app.update();  // 0, 1, 2, 3
+        app.update();  // 1, 2, 3
+        app.update();  // 2, 3, completed with Failure
+        app.update();  // nop
+        // Order of the log entries within same frame may change.
+        let expected: HashSet<TestLogEntry> = vec![
+            TestLogEntry {task_id: 0, updated_count: 0, frame: 1},
+            TestLogEntry {task_id: 1, updated_count: 0, frame: 1},
+            TestLogEntry {task_id: 2, updated_count: 0, frame: 1},
+            TestLogEntry {task_id: 3, updated_count: 0, frame: 1},
+            TestLogEntry {task_id: 1, updated_count: 1, frame: 2},
+            TestLogEntry {task_id: 2, updated_count: 1, frame: 2},
+            TestLogEntry {task_id: 3, updated_count: 1, frame: 2},
+            TestLogEntry {task_id: 2, updated_count: 2, frame: 3},
+            TestLogEntry {task_id: 3, updated_count: 2, frame: 3},
+        ].into_iter().collect();
+        let found: HashSet<TestLogEntry> = app.world.get_resource::<TestLog>().unwrap().log.clone().into_iter().collect();
+        assert!(
+            found == expected,
+            "ParallelAnd should match result. found: {:?}", found
+        );
+    }
+
+    #[test]
+    fn test_or() {
+        let mut app = App::new();
+        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        let parallel = ParallelOr::new(vec![
+            TesterTask::<0>::new(1, TaskState::Failure),
+            TesterTask::<1>::new(2, TaskState::Failure),
+            TesterTask::<2>::new(3, TaskState::Success),
+            TesterTask::<3>::new(4, TaskState::Failure),
+        ]);
+        let tree = BehaviorTree::new(parallel);
+        let _entity = app.world.spawn(tree).id();
+        app.update();
+        app.update();  // 0, 1, 2, 3
+        app.update();  // 1, 2, 3
+        app.update();  // 2, 3, complete with Success
+        app.update();  // nop
+        // Order of the log entries within same frame may change.
+        let expected: HashSet<TestLogEntry> = vec![
+            TestLogEntry {task_id: 0, updated_count: 0, frame: 1},
+            TestLogEntry {task_id: 1, updated_count: 0, frame: 1},
+            TestLogEntry {task_id: 2, updated_count: 0, frame: 1},
+            TestLogEntry {task_id: 3, updated_count: 0, frame: 1},
+            TestLogEntry {task_id: 1, updated_count: 1, frame: 2},
+            TestLogEntry {task_id: 2, updated_count: 1, frame: 2},
+            TestLogEntry {task_id: 3, updated_count: 1, frame: 2},
+            TestLogEntry {task_id: 2, updated_count: 2, frame: 3},
+            TestLogEntry {task_id: 3, updated_count: 2, frame: 3},
+        ].into_iter().collect();
+        let found: HashSet<TestLogEntry> = app.world.get_resource::<TestLog>().unwrap().log.clone().into_iter().collect();
+        assert!(
+            found == expected,
+            "ParallelOr should match result. found: {:?}", found
+        );
+    }
+
+    #[test]
+    fn test_join() {
+        let mut app = App::new();
+        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        let parallel = Join::new(vec![
+            TesterTask::<0>::new(1, TaskState::Success),
+            TesterTask::<1>::new(2, TaskState::Success),
+            TesterTask::<2>::new(3, TaskState::Failure),
+            TesterTask::<3>::new(4, TaskState::Success),
+        ]);
+        let tree = BehaviorTree::new(parallel);
+        let _entity = app.world.spawn(tree).id();
+        app.update();
+        app.update();  // 0, 1, 2, 3
+        app.update();  // 1, 2, 3
+        app.update();  // 2, 3
+        app.update();  // 3, parallel completed
+        app.update();  // nop
+        // Order of the log entries within same frame may change.
+        let expected: HashSet<TestLogEntry> = vec![
+            TestLogEntry {task_id: 0, updated_count: 0, frame: 1},
+            TestLogEntry {task_id: 1, updated_count: 0, frame: 1},
+            TestLogEntry {task_id: 2, updated_count: 0, frame: 1},
+            TestLogEntry {task_id: 3, updated_count: 0, frame: 1},
+            TestLogEntry {task_id: 1, updated_count: 1, frame: 2},
+            TestLogEntry {task_id: 2, updated_count: 1, frame: 2},
+            TestLogEntry {task_id: 3, updated_count: 1, frame: 2},
+            TestLogEntry {task_id: 2, updated_count: 2, frame: 3},
+            TestLogEntry {task_id: 3, updated_count: 2, frame: 3},
+            TestLogEntry {task_id: 3, updated_count: 3, frame: 4},
+        ].into_iter().collect();
+        let found: HashSet<TestLogEntry> = app.world.get_resource::<TestLog>().unwrap().log.clone().into_iter().collect();
+        assert!(
+            found == expected,
+            "Join should match result. found: {:?}", found
+        );
+    }
+
+}

--- a/src/sequential/variants/mod.rs
+++ b/src/sequential/variants/mod.rs
@@ -96,10 +96,10 @@ mod tests {
     fn test_sequential_and() {
         let mut app = App::new();
         app.add_plugins((BehaviorTreePlugin, TesterPlugin));
-        let task0 = TesterTask::new(0, 1, TaskState::Success);
-        let task1 = TesterTask::new(1, 1, TaskState::Success);
-        let task2 = TesterTask::new(2, 1, TaskState::Failure);
-        let task3 = TesterTask::new(3, 1, TaskState::Success);
+        let task0 = TesterTask::<0>::new(1, TaskState::Success);
+        let task1 = TesterTask::<1>::new(1, TaskState::Success);
+        let task2 = TesterTask::<2>::new(1, TaskState::Failure);
+        let task3 = TesterTask::<3>::new(1, TaskState::Success);
         let sequence = Sequence::new(vec![task0, task1, task2, task3]);
         let tree = BehaviorTree::new(sequence);
         let _entity = app.world.spawn(tree).id();
@@ -123,10 +123,10 @@ mod tests {
     fn test_sequential_or() {
         let mut app = App::new();
         app.add_plugins((BehaviorTreePlugin, TesterPlugin));
-        let task0 = TesterTask::new(0, 1, TaskState::Failure);
-        let task1 = TesterTask::new(1, 1, TaskState::Failure);
-        let task2 = TesterTask::new(2, 1, TaskState::Success);
-        let task3 = TesterTask::new(3, 1, TaskState::Failure);
+        let task0 = TesterTask::<0>::new(1, TaskState::Failure);
+        let task1 = TesterTask::<1>::new(1, TaskState::Failure);
+        let task2 = TesterTask::<2>::new(1, TaskState::Success);
+        let task3 = TesterTask::<3>::new(1, TaskState::Failure);
         let sequence = Selector::new(vec![task0, task1, task2, task3]);
         let tree = BehaviorTree::new(sequence);
         let _entity = app.world.spawn(tree).id();
@@ -150,10 +150,10 @@ mod tests {
     fn test_forced_sequence() {
         let mut app = App::new();
         app.add_plugins((BehaviorTreePlugin, TesterPlugin));
-        let task0 = TesterTask::new(0, 1, TaskState::Success);
-        let task1 = TesterTask::new(1, 1, TaskState::Failure);
-        let task2 = TesterTask::new(2, 1, TaskState::Success);
-        let task3 = TesterTask::new(3, 1, TaskState::Failure);
+        let task0 = TesterTask::<0>::new(1, TaskState::Success);
+        let task1 = TesterTask::<1>::new(1, TaskState::Failure);
+        let task2 = TesterTask::<2>::new(1, TaskState::Success);
+        let task3 = TesterTask::<3>::new(1, TaskState::Failure);
         let sequence = ForcedSequence::new(vec![task0, task1, task2, task3]);
         let tree = BehaviorTree::new(sequence);
         let _entity = app.world.spawn(tree).id();

--- a/src/sequential/variants/random.rs
+++ b/src/sequential/variants/random.rs
@@ -148,19 +148,19 @@ mod tests {
             vec![
                 Box::new(NodeScorerImpl::new(
                     ConstantScorer {score: 0.1},
-                    TesterTask::new(0, 1, TaskState::Failure)
+                    TesterTask::<0>::new(1, TaskState::Failure)
                 )),
                 Box::new(NodeScorerImpl::new(
                     ConstantScorer {score: 0.3},
-                    TesterTask::new(1, 1, TaskState::Success)
+                    TesterTask::<1>::new(1, TaskState::Success)
                 )),
                 Box::new(NodeScorerImpl::new(
                     ConstantScorer {score: 0.2},
-                    TesterTask::new(2, 1, TaskState::Success)
+                    TesterTask::<2>::new(1, TaskState::Success)
                 )),
                 Box::new(NodeScorerImpl::new(
                     ConstantScorer {score: 0.4},
-                    TesterTask::new(3, 1, TaskState::Success)
+                    TesterTask::<3>::new(1, TaskState::Success)
                 )),
             ],
             Arc::new(Mutex::new(rand::rngs::StdRng::seed_from_u64(224)))
@@ -192,19 +192,19 @@ mod tests {
             vec![
                 Box::new(NodeScorerImpl::new(
                     ConstantScorer {score: 0.1},
-                    TesterTask::new(0, 1, TaskState::Success)
+                    TesterTask::<0>::new(1, TaskState::Success)
                 )),
                 Box::new(NodeScorerImpl::new(
                     ConstantScorer {score: 0.3},
-                    TesterTask::new(1, 1, TaskState::Failure)
+                    TesterTask::<1>::new(1, TaskState::Failure)
                 )),
                 Box::new(NodeScorerImpl::new(
                     ConstantScorer {score: 0.2},
-                    TesterTask::new(2, 1, TaskState::Failure)
+                    TesterTask::<2>::new(1, TaskState::Failure)
                 )),
                 Box::new(NodeScorerImpl::new(
                     ConstantScorer {score: 0.4},
-                    TesterTask::new(3, 1, TaskState::Failure)
+                    TesterTask::<3>::new(1, TaskState::Failure)
                 )),
             ],
             Arc::new(Mutex::new(rand::rngs::StdRng::seed_from_u64(224)))
@@ -236,19 +236,19 @@ mod tests {
             vec![
                 Box::new(NodeScorerImpl::new(
                     ConstantScorer {score: 0.1},
-                    TesterTask::new(0, 1, TaskState::Failure)
+                    TesterTask::<0>::new(1, TaskState::Failure)
                 )),
                 Box::new(NodeScorerImpl::new(
                     ConstantScorer {score: 0.3},
-                    TesterTask::new(1, 1, TaskState::Failure)
+                    TesterTask::<1>::new(1, TaskState::Failure)
                 )),
                 Box::new(NodeScorerImpl::new(
                     ConstantScorer {score: 0.2},
-                    TesterTask::new(2, 1, TaskState::Success)
+                    TesterTask::<2>::new(1, TaskState::Success)
                 )),
                 Box::new(NodeScorerImpl::new(
                     ConstantScorer {score: 0.4},
-                    TesterTask::new(3, 1, TaskState::Failure)
+                    TesterTask::<3>::new(1, TaskState::Failure)
                 )),
             ],
             Arc::new(Mutex::new(rand::rngs::StdRng::seed_from_u64(224)))
@@ -282,19 +282,19 @@ mod tests {
             vec![
                 Box::new(NodeScorerImpl::new(
                     ConstantScorer {score: 0.1},
-                    TesterTask::new(0, 1, TaskState::Failure)
+                    TesterTask::<0>::new(1, TaskState::Failure)
                 )),
                 Box::new(NodeScorerImpl::new(
                     ConstantScorer {score: 0.3},
-                    TesterTask::new(1, 1, TaskState::Failure)
+                    TesterTask::<1>::new(1, TaskState::Failure)
                 )),
                 Box::new(NodeScorerImpl::new(
                     ConstantScorer {score: 0.2},
-                    TesterTask::new(2, 1, TaskState::Success)
+                    TesterTask::<2>::new(1, TaskState::Success)
                 )),
                 Box::new(NodeScorerImpl::new(
                     ConstantScorer {score: 10.4},
-                    TesterTask::new(3, 1, TaskState::Failure)
+                    TesterTask::<3>::new(1, TaskState::Failure)
                 )),
             ],
             Arc::new(Mutex::new(rand::rngs::StdRng::seed_from_u64(224)))

--- a/src/sequential/variants/sorted.rs
+++ b/src/sequential/variants/sorted.rs
@@ -119,19 +119,19 @@ mod tests {
         let sequence = ScoreOrderedSequentialAnd::new(vec![
             Box::new(NodeScorerImpl::new(
                 ConstantScorer {score: 0.1},
-                TesterTask::new(0, 1, TaskState::Success)
+                TesterTask::<0>::new(1, TaskState::Success)
             )),
             Box::new(NodeScorerImpl::new(
                 ConstantScorer {score: 0.3},
-                TesterTask::new(1, 1, TaskState::Success)
+                TesterTask::<1>::new(1, TaskState::Success)
             )),
             Box::new(NodeScorerImpl::new(
                 ConstantScorer {score: 0.2},
-                TesterTask::new(2, 1, TaskState::Failure)
+                TesterTask::<2>::new(1, TaskState::Failure)
             )),
             Box::new(NodeScorerImpl::new(
                 ConstantScorer {score: 0.4},
-                TesterTask::new(3, 1, TaskState::Success)
+                TesterTask::<3>::new(1, TaskState::Success)
             )),
         ]);
         let tree = BehaviorTree::new(sequence);
@@ -159,19 +159,19 @@ mod tests {
         let sequence = ScoreOrderedSequentialOr::new(vec![
             Box::new(NodeScorerImpl::new(
                 ConstantScorer {score: 0.1},
-                TesterTask::new(0, 1, TaskState::Failure)
+                TesterTask::<0>::new(1, TaskState::Failure)
             )),
             Box::new(NodeScorerImpl::new(
                 ConstantScorer {score: 0.3},
-                TesterTask::new(1, 1, TaskState::Failure)
+                TesterTask::<1>::new(1, TaskState::Failure)
             )),
             Box::new(NodeScorerImpl::new(
                 ConstantScorer {score: 0.2},
-                TesterTask::new(2, 1, TaskState::Success)
+                TesterTask::<2>::new(1, TaskState::Success)
             )),
             Box::new(NodeScorerImpl::new(
                 ConstantScorer {score: 0.4},
-                TesterTask::new(3, 1, TaskState::Failure)
+                TesterTask::<3>::new(1, TaskState::Failure)
             )),
         ]);
         let tree = BehaviorTree::new(sequence);
@@ -199,19 +199,19 @@ mod tests {
         let sequence = ScoreOrderedForcedSequence::new(vec![
             Box::new(NodeScorerImpl::new(
                 ConstantScorer {score: 0.1},
-                TesterTask::new(0, 1, TaskState::Failure)
+                TesterTask::<0>::new(1, TaskState::Failure)
             )),
             Box::new(NodeScorerImpl::new(
                 ConstantScorer {score: 0.3},
-                TesterTask::new(1, 1, TaskState::Failure)
+                TesterTask::<1>::new(1, TaskState::Failure)
             )),
             Box::new(NodeScorerImpl::new(
                 ConstantScorer {score: 0.2},
-                TesterTask::new(2, 1, TaskState::Success)
+                TesterTask::<2>::new(1, TaskState::Success)
             )),
             Box::new(NodeScorerImpl::new(
                 ConstantScorer {score: 0.4},
-                TesterTask::new(3, 1, TaskState::Failure)
+                TesterTask::<3>::new(1, TaskState::Failure)
             )),
         ]);
         let tree = BehaviorTree::new(sequence);
@@ -241,19 +241,19 @@ mod tests {
         let sequence = ScoredForcedSelector::new(vec![
             Box::new(NodeScorerImpl::new(
                 ConstantScorer {score: 0.1},
-                TesterTask::new(0, 1, TaskState::Failure)
+                TesterTask::<0>::new(1, TaskState::Failure)
             )),
             Box::new(NodeScorerImpl::new(
                 ConstantScorer {score: 0.3},
-                TesterTask::new(1, 1, TaskState::Failure)
+                TesterTask::<1>::new(1, TaskState::Failure)
             )),
             Box::new(NodeScorerImpl::new(
                 ConstantScorer {score: 0.2},
-                TesterTask::new(2, 1, TaskState::Success)
+                TesterTask::<2>::new(1, TaskState::Success)
             )),
             Box::new(NodeScorerImpl::new(
                 ConstantScorer {score: 0.4},
-                TesterTask::new(3, 1, TaskState::Failure)
+                TesterTask::<3>::new(1, TaskState::Failure)
             )),
         ]);
         let tree = BehaviorTree::new(sequence);


### PR DESCRIPTION
Added `Parallel` and variants ( #6 ).
Includes some change for internal `tester_util`.
Refactoring may change something on starting `BehaviorTree` with `Abort`.