### PR TITLE
Configurable schedule

### DIFF
--- a/examples/chase.rs
+++ b/examples/chase.rs
@@ -7,7 +7,7 @@ use bevior_tree::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins((DefaultPlugins, BehaviorTreePlugin))
+        .add_plugins((DefaultPlugins, BehaviorTreePlugin::default()))
         // This plugin is required for `bevior_tree`
         .add_systems(Startup, init)
         .add_systems(Update, (follow, move_player))

--- a/src/conditional/variants.rs
+++ b/src/conditional/variants.rs
@@ -215,7 +215,7 @@ mod tests {
     #[test]
     fn test_conditional_false() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let task = TesterTask::<0>::new(1, TaskState::Success);
         let conditional = Conditional::new(task, TestMarkerExists);
         let tree = BehaviorTree::new(conditional);
@@ -233,7 +233,7 @@ mod tests {
     #[test]
     fn test_conditional_true() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let task = TesterTask::<0>::new(1, TaskState::Success);
         let conditional = Conditional::new(task, TestMarkerExists);
         let tree = BehaviorTree::new(conditional);
@@ -253,7 +253,7 @@ mod tests {
     #[test]
     fn test_check_if_false() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let task = CheckIf::new(TestMarkerExists);
         let tree = BehaviorTree::new(task);
         let entity = app.world.spawn(tree).id();
@@ -269,7 +269,7 @@ mod tests {
     #[test]
     fn test_check_if_true() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let task = CheckIf::new(TestMarkerExists);
         let tree = BehaviorTree::new(task);
         let entity = app.world.spawn((tree, TestMarker)).id();
@@ -285,7 +285,7 @@ mod tests {
     #[test]
     fn test_repeat_count() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let task = TesterTask::<0>::new(1, TaskState::Success);
         let repeater = ConditionalLoop::new(task, RepeatCount {count: 3});
         let tree = BehaviorTree::new(repeater);

--- a/src/converter/variants.rs
+++ b/src/converter/variants.rs
@@ -48,7 +48,7 @@ mod tests {
     #[test]
     fn test_invert() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let task = TesterTask::<0>::new(1, TaskState::Success);
         let converter = Invert::new(task);
         let tree = BehaviorTree::new(converter);
@@ -65,7 +65,7 @@ mod tests {
     #[test]
     fn test_force_result() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let task = TesterTask::<0>::new(1, TaskState::Success);
         let converter = ForceResult::new(task, NodeResult::Failure);
         let tree = BehaviorTree::new(converter);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ pub struct BehaviorTree {
     world: Arc<Mutex<NullableWorldAccess>>,
 }
 /// Add to the same entity with the BehaviorTree to temporarily freeze the update.
+/// You may prefer `ElseFreeze` node in `conditional`.
 #[derive(Component)]
 pub struct Freeze;
 /// Add to the same entity with the BehaviorTree to abort the process.

--- a/src/parallel/variants.rs
+++ b/src/parallel/variants.rs
@@ -101,7 +101,7 @@ mod tests {
     #[test]
     fn test_abort() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let parallel = Join::new(vec![
             TesterTask::<0>::new(1, TaskState::Success),
             TesterTask::<1>::new(2, TaskState::Success),
@@ -135,7 +135,7 @@ mod tests {
     #[test]
     fn test_and() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let parallel = ParallelAnd::new(vec![
             TesterTask::<0>::new(1, TaskState::Success),
             TesterTask::<1>::new(2, TaskState::Success),
@@ -171,7 +171,7 @@ mod tests {
     #[test]
     fn test_or() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let parallel = ParallelOr::new(vec![
             TesterTask::<0>::new(1, TaskState::Failure),
             TesterTask::<1>::new(2, TaskState::Failure),
@@ -207,7 +207,7 @@ mod tests {
     #[test]
     fn test_join() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let parallel = Join::new(vec![
             TesterTask::<0>::new(1, TaskState::Success),
             TesterTask::<1>::new(2, TaskState::Success),

--- a/src/sequential/variants/mod.rs
+++ b/src/sequential/variants/mod.rs
@@ -113,7 +113,7 @@ mod tests {
     #[test]
     fn test_sequential_and() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let task0 = TesterTask::<0>::new(1, TaskState::Success);
         let task1 = TesterTask::<1>::new(1, TaskState::Success);
         let task2 = TesterTask::<2>::new(1, TaskState::Failure);
@@ -140,7 +140,7 @@ mod tests {
     #[test]
     fn test_sequential_or() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let task0 = TesterTask::<0>::new(1, TaskState::Failure);
         let task1 = TesterTask::<1>::new(1, TaskState::Failure);
         let task2 = TesterTask::<2>::new(1, TaskState::Success);
@@ -167,7 +167,7 @@ mod tests {
     #[test]
     fn test_forced_sequence() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let task0 = TesterTask::<0>::new(1, TaskState::Success);
         let task1 = TesterTask::<1>::new(1, TaskState::Failure);
         let task2 = TesterTask::<2>::new(1, TaskState::Success);

--- a/src/sequential/variants/random.rs
+++ b/src/sequential/variants/random.rs
@@ -145,7 +145,7 @@ mod tests {
     #[test]
     fn test_random_ordered_sequential_and() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let sequence = RandomOrderedSequentialAnd::new(
             vec![
                 Box::new(NodeScorerImpl::new(
@@ -189,7 +189,7 @@ mod tests {
     #[test]
     fn test_random_ordered_sequential_or() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let sequence = RandomOrderedSequentialOr::new(
             vec![
                 Box::new(NodeScorerImpl::new(
@@ -233,7 +233,7 @@ mod tests {
     #[test]
     fn test_random_ordered_forced_sequence() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let sequence = RandomOrderedForcedSequence::new(
             vec![
                 Box::new(NodeScorerImpl::new(
@@ -279,7 +279,7 @@ mod tests {
     #[test]
     fn test_random_forced_selector() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let sequence = RandomForcedSelector::new(
             vec![
                 Box::new(NodeScorerImpl::new(

--- a/src/sequential/variants/sorted.rs
+++ b/src/sequential/variants/sorted.rs
@@ -116,7 +116,7 @@ mod tests {
     #[test]
     fn test_score_ordered_sequential_and() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let sequence = ScoreOrderedSequentialAnd::new(vec![
             Box::new(NodeScorerImpl::new(
                 ConstantScorer {score: 0.1},
@@ -156,7 +156,7 @@ mod tests {
     #[test]
     fn test_score_ordered_sequential_or() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let sequence = ScoreOrderedSequentialOr::new(vec![
             Box::new(NodeScorerImpl::new(
                 ConstantScorer {score: 0.1},
@@ -196,7 +196,7 @@ mod tests {
     #[test]
     fn test_score_ordered_forced_sequence() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let sequence = ScoreOrderedForcedSequence::new(vec![
             Box::new(NodeScorerImpl::new(
                 ConstantScorer {score: 0.1},
@@ -238,7 +238,7 @@ mod tests {
     #[test]
     fn test_score_ordered_forced_selector() {
         let mut app = App::new();
-        app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+        app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
         let sequence = ScoredForcedSelector::new(vec![
             Box::new(NodeScorerImpl::new(
                 ConstantScorer {score: 0.1},

--- a/src/tester_util.rs
+++ b/src/tester_util.rs
@@ -98,7 +98,7 @@ fn update<const ID: i32>(
 #[test]
 fn test_enter_tester_task() {
     let mut app = App::new();
-    app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+    app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
     let task = TesterTask::<0>::new(1, TaskState::Success);
     let tree = BehaviorTree::new(task);
     let entity = app.world.spawn(tree).id();
@@ -114,7 +114,7 @@ fn test_enter_tester_task() {
 #[test]
 fn test_exit_tester_task() {
     let mut app = App::new();
-    app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+    app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
     let task = TesterTask::<0>::new(1, TaskState::Success);
     let tree = BehaviorTree::new(task);
     let entity = app.world.spawn(tree).id();
@@ -129,7 +129,7 @@ fn test_exit_tester_task() {
 #[test]
 fn test_log_test_task() {
     let mut app = App::new();
-    app.add_plugins((BehaviorTreePlugin, TesterPlugin));
+    app.add_plugins((BehaviorTreePlugin::default(), TesterPlugin));
     let task = TesterTask::<0>::new(1, TaskState::Success);
     let tree = BehaviorTree::new(task);
     let _entity = app.world.spawn(tree).id();


### PR DESCRIPTION
Behavior tree can now configure when to run, like mentioned in ( #18 ).

## Breaking Changes
`BehaviorTreePlugin` now has member, so call `default()` to create it.